### PR TITLE
a fix for spurious NaNs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-09-03  Fabien Le Floc'h  <fabien@2ipi.com>
+        * DESCRIPTION (Version): New version is 1.6-1
+    
+        * src/solve.QP.compact.f, src/solve.QP.f : Changed temp variable 
+        calculation to avoid NaNs related to double underflow.
+
 2013-04-17  Berwin A Turlach  <Berwin.Turlach@gmail.com>
 
 	* DESCRIPTION (Version): New versin is 1.5-5

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,16 @@
 Package: quadprog
 Type: Package
 Title: Functions to solve Quadratic Programming Problems.
-Version: 1.5-5
-Date: 2013-04-17
+Version: 1.6-1
+Date: 2018-09-03
 Author: S original by Berwin A. Turlach <Berwin.Turlach@gmail.com> R
         port by Andreas Weingessel <Andreas.Weingessel@ci.tuwien.ac.at>
-Maintainer: Berwin A. Turlach <Berwin.Turlach@gmail.com>
+Maintainer: Berwin A. Turlach <Berwin.Turlach@gmail.com>, Fabien Le Floc'h <fabien@2ipi.com>
 Description: This package contains routines and documentation for
         solving quadratic programming problems.
 Depends: R (>= 2.15.0)
 License: GPL (>= 2)
-Packaged: 2013-04-17 08:35:43 UTC; berwin
+Packaged: 2018-09-03 08:35:43 UTC; fabien
 NeedsCompilation: yes
 Repository: CRAN
-Date/Publication: 2013-04-17 13:42:49
+Date/Publication: 2018-09-03 13:42:49

--- a/src/solve.QP.compact.f
+++ b/src/solve.QP.compact.f
@@ -419,7 +419,7 @@ c
                   if (work(i) .EQ. 0.d0) goto 160
                   gc   = max(abs(work(i-1)),abs(work(i)))
                   gs   = min(abs(work(i-1)),abs(work(i)))
-                  temp = sign(gc*sqrt(1+gs*gs/(gc*gc)), work(i-1))
+                  temp = sign(gc*sqrt(1+(gs/gc)*(gs/gc)), work(i-1))
                   gc   = work(i-1)/temp
                   gs   = work(i)/temp
 c 
@@ -507,7 +507,7 @@ c
       if (work(l1) .EQ. 0.d0) goto 798
       gc   = max(abs(work(l1-1)),abs(work(l1)))
       gs   = min(abs(work(l1-1)),abs(work(l1)))
-      temp = sign(gc*sqrt(1+gs*gs/(gc*gc)), work(l1-1))
+      temp = sign(gc*sqrt(1+(gs/gc)*(gs/gc)), work(l1-1))
       gc   = work(l1-1)/temp
       gs   = work(l1)/temp
 c 

--- a/src/solve.QP.f
+++ b/src/solve.QP.f
@@ -410,7 +410,7 @@ c
                   if (work(i) .EQ. 0.d0) goto 160
                   gc   = max(abs(work(i-1)),abs(work(i)))
                   gs   = min(abs(work(i-1)),abs(work(i)))
-                  temp = sign(gc*sqrt(1+gs*gs/(gc*gc)), work(i-1))
+                  temp = sign(gc*sqrt(1+(gs/gc)*(gs/gc)), work(i-1))
                   gc   = work(i-1)/temp
                   gs   = work(i)/temp
 c 
@@ -498,7 +498,7 @@ c
       if (work(l1) .EQ. 0.d0) goto 798
       gc   = max(abs(work(l1-1)),abs(work(l1)))
       gs   = min(abs(work(l1-1)),abs(work(l1)))
-      temp = sign(gc*sqrt(1+gs*gs/(gc*gc)), work(l1-1))
+      temp = sign(gc*sqrt(1+(gs/gc)*(gs/gc)), work(l1-1))
       gc   = work(l1-1)/temp
       gs   = work(l1)/temp
 c 


### PR DESCRIPTION
I encountered issues similar to this thread 
https://stat.ethz.ch/pipermail/r-help//2014-September/422051.html

NaN are sometimes produced without any particular reason, when the problem is very well defined. It turns out it is due to a double number underflow in the code. This change fixes that problem.